### PR TITLE
Add Events capacity to Backbone.Network

### DIFF
--- a/backbone.extend.js
+++ b/backbone.extend.js
@@ -417,6 +417,8 @@
 		this.__middleware = [];
 	};
 
+	Backbone.Network.prototype = _.extend(Backbone.Network.prototype, Backbone.Events);
+
 	Backbone.Network.prototype.setUrl = function (url) {
 		this.__url = url;
 		return (this);
@@ -446,8 +448,10 @@
 		var callbackEnd = (function (request, next) {
 			var x = $.ajax(request.options)
 			.done(function (res) {
+				self.trigger('done', res);
 				callback.apply(ctx || this, [null, res]);
 			}).fail(function () {
+				self.trigger('fail', res);
 				callback.apply(ctx || this, arguments);
 			});
 			return (x);

--- a/backbone.extend.js
+++ b/backbone.extend.js
@@ -444,7 +444,7 @@
 		var Request = {
 			options: opts
 		};
-
+		var self = this;
 		var callbackEnd = (function (request, next) {
 			var x = $.ajax(request.options)
 			.done(function (res) {


### PR DESCRIPTION
Events:
 - done: when request is resolved, called just before the callback. send the response as first parameter
 - fail: when request is rejected, called just before the callback. send the response as first parameter